### PR TITLE
feat: 新規登録実装

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,7 @@
 {
+  "printWidth": 120,
+  "tabWidth": 2,
+  "useTabs": false,
   "plugins": [
     "prettier-plugin-tailwindcss"
   ],
@@ -9,7 +12,13 @@
         "*.html.erb"
       ],
       "options": {
-        "parser": "html"
+        "parser": "html",
+        "printWidth": 120,
+        "tabWidth": 2,
+        "useTabs": false,
+        "htmlWhitespaceSensitivity": "ignore",
+        "embeddedLanguageFormatting": "auto",
+        "bracketSameLine": false
       }
     }
   ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,17 +38,20 @@ Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 
 Metrics/BlockLength:
-  Max: 25
+  Max: 30
   Exclude:
     - "spec/**/*"
     - "config/**/*"
 
 Metrics/MethodLength:
-  Max: 15
+  Max: 30
 
 Metrics/ClassLength:
-  Max: 150
+  Max: 200
 
 Metrics/AbcSize:
-  Max: 20
+  Max: 30
+
+Rails/I18nLocaleTexts:
+  Enabled: false
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,11 +4,19 @@
     "*.erb": "erb",
     "*.html.erb": "erb"
   },
-  "prettier.documentSelectors": [
-    "**/*.erb",
-    "**/*.html.erb"
-  ],
   "[erb]": {
+    "editor.formatOnSave": false,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false
+  },
+  "[html]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[css]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   }
 }

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -7,7 +7,8 @@
   --color-gray: #4a4c56;
   --color-cation: #d54a4a;
   --color-theme: #b6ff51;
-  ----default-font-family: "Noto Sans JP", sans-serif;
+  --default-font-family: "Noto Sans JP", sans-serif;
+  --default-font-weight: 400;
 
   --animate-flash-message: flash-message 3s ease-in-out forwards;
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  add_flash_types :success, :error
   before_action :authenticate_user!
 end

--- a/app/controllers/user/registrations_controller.rb
+++ b/app/controllers/user/registrations_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class User::RegistrationsController < Devise::RegistrationsController
-end

--- a/app/controllers/user/sessions_controller.rb
+++ b/app/controllers/user/sessions_controller.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class User::SessionsController < Devise::SessionsController
-end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  skip_before_action :authenticate_user!
+
+  def new
+    super
+    @user = User.new
+  end
+
+  def create
+    super
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to root_path, success: "アカウントを登録しました"
+    else
+      flash.now[:error] = "アカウントの登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -9,7 +9,27 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def create
-    super
+    build_resource(sign_up_params)
+
+    resource.save
+    yield resource if block_given?
+
+    if resource.persisted?
+        sign_up(resource_name, resource)
+        redirect_to root_path, success: "アカウント登録に成功しました"
+    else
+      clean_up_passwords resource
+      set_minimum_password_length
+      flash.now[:error] = "アカウント登録に失敗しました"
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  protected
+
+
+  def after_inactive_sign_up_path_for(resource)
+    root_path
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -15,8 +15,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
     yield resource if block_given?
 
     if resource.persisted?
-        sign_up(resource_name, resource)
-        redirect_to root_path, success: "アカウント登録に成功しました"
+      sign_up(resource_name, resource)
+      redirect_to root_path, success: "アカウント登録に成功しました"
     else
       clean_up_passwords resource
       set_minimum_password_length
@@ -27,14 +27,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   protected
 
-
-  def after_inactive_sign_up_path_for(resource)
+  def after_inactive_sign_up_path_for(_resource)
     root_path
   end
 
   private
 
   def sign_up_params
-    params.require(:user).permit(:name, :email, :password, :password_confirmation)
+    params.expect(user: %i[name email password password_confirmation])
   end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -10,18 +10,11 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def create
     super
-    @user = User.new(user_params)
-    if @user.save
-      redirect_to root_path, success: "アカウントを登録しました"
-    else
-      flash.now[:error] = "アカウントの登録に失敗しました"
-      render :new, status: :unprocessable_entity
-    end
   end
 
   private
 
-  def user_params
+  def sign_up_params
     params.require(:user).permit(:name, :email, :password, :password_confirmation)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,7 @@
 module ApplicationHelper
+  def field_error_message(model, field)
+    return unless model&.errors && model.errors[field].any?
+
+    content_tag :span, model.errors[field].first, class: "text-red-500 text-sm mt-1 block"
+  end
 end

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,7 +1,17 @@
-<div
-  id="toast-success"
-  class="bg-primary animate-flash-message border-theme flex w-full max-w-xs items-center rounded-lg border-l-4 p-4 text-white shadow-sm"
-  role="alert"
->
-  <span class="ms-3 text-sm font-normal">ここにフラッシュメッセージ</span>
-</div>
+<% if flash[:success] %>
+  <div
+    id="toast-success"
+    class="bg-primary animate-flash-message border-theme flex w-full max-w-xs items-center rounded-lg border-l-4 p-4 text-white shadow-sm"
+    role="alert"
+  >
+    <span class="ms-3 text-sm font-normal"><%= flash[:success] %></span>
+  </div>
+<% elsif flash[:error] %>
+  <div
+    id="toast-error"
+    class="bg-primary animate-flash-message border-red-400 flex w-full max-w-xs items-center rounded-lg border-l-4 p-4 text-white shadow-sm"
+    role="alert"
+  >
+    <span class="ms-3 text-sm font-normal"><%= flash[:error] %></span>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -2,10 +2,7 @@
   <h1 class="text-theme text-2xl font-bold italic">TOPI LOG</h1>
   <nav>
     <ul class="flex items-center justify-center space-x-4">
-      <li>
-        <%= link_to "ログイン", "#", class: "inline-block bg-theme rounded-full
-        px-5 py-1 text-primary font-semibold" %>
-      </li>
+      <% if user_signed_in? %>
       <li>
         <%= button_to "ログアウト", "#", class: "inline-block border-2
         border-theme rounded-full px-5 py-1 text-theme font-semibold" %>
@@ -14,6 +11,12 @@
         <%= link_to "マイページ", "#", class: "inline-block bg-theme
         rounded-full px-5 py-1 text-primary font-semibold" %>
       </li>
+      <% else %>
+        <li>
+          <%= link_to "ログイン", "#", class: "inline-block bg-theme rounded-full
+          px-5 py-1 text-primary font-semibold" %>
+        </li>
+      <% end %>
     </ul>
   </nav>
 </div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -1,1 +1,40 @@
-新規登録ページ
+<div class="flex flex-col justify-center items-center max-w-2xl w-full gap-y-10">
+  <article class="bg-primary text-white flex flex-col justify-center items-center max-w-md w-full rounded-2xl">
+    <h1 class="text-theme text-2xl text-center border-b border-gray py-3 w-full">ユーザー新規登録</h1>
+    <%= form_with model: @user, url: user_registration_path, class: "flex flex-col justify-start items-center w-full px-4 py-4 rounded-xl gap-y-4" do |f| %>
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <div>
+          <%= f.label :name %><span class="text-red-400">*</span>
+        </div>
+        <%= f.text_field :name, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "example name", required: true %>
+      </div>
+
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <div>
+          <%= f.label :email %><span class="text-red-400">*</span>
+        </div>
+        <%= f.email_field :email, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "example@example.com", required: true %>
+      </div>
+
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <div>
+          <%= f.label :password %><span class="text-red-400">*</span>
+        </div>
+        <%= f.password_field :password, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "6文字以上", required: true %>
+      </div>
+
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <div>
+          <%= f.label :password_confirmation %><span class="text-red-400">*</span>
+        </div>
+        <%= f.password_field :password_confirmation, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "確認用パスワード", required: true %>
+      </div>
+
+      <div class="flex justify-center items-center">
+        <%= f.submit "登録する", class: "bg-theme text-primary px-4 py-2 rounded-full hover:opacity-50 transition-all cursor-pointer" %>
+      </div>
+    <% end %>
+  </article>
+
+  <p><%= link_to "登録済みの場合はこちら", "", class: "text-white underline hover:text-gray transition-all" %></p>
+</div>

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -6,6 +6,7 @@
         <div>
           <%= f.label :name %><span class="text-red-400">*</span>
         </div>
+        <%= field_error_message(resource, :name) %>
         <%= f.text_field :name, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "example name", required: true %>
       </div>
 
@@ -13,6 +14,7 @@
         <div>
           <%= f.label :email %><span class="text-red-400">*</span>
         </div>
+        <%= field_error_message(resource, :email) %>
         <%= f.email_field :email, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "example@example.com", required: true %>
       </div>
 
@@ -20,6 +22,7 @@
         <div>
           <%= f.label :password %><span class="text-red-400">*</span>
         </div>
+        <%= field_error_message(resource, :password) %>
         <%= f.password_field :password, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "6文字以上", required: true %>
       </div>
 
@@ -27,6 +30,7 @@
         <div>
           <%= f.label :password_confirmation %><span class="text-red-400">*</span>
         </div>
+        <%= field_error_message(resource, :password_confirmation) %>
         <%= f.password_field :password_confirmation, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "確認用パスワード", required: true %>
       </div>
 

--- a/config/initializers/field_error_proc.rb
+++ b/config/initializers/field_error_proc.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# field_with_errorsの標準的なdivラッパーを無効化
 ActionView::Base.field_error_proc = proc do |html_tag, _instance|
-  html_tag.html_safe
+  html_tag
 end

--- a/config/initializers/field_error_proc.rb
+++ b/config/initializers/field_error_proc.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# field_with_errorsの標準的なdivラッパーを無効化
+ActionView::Base.field_error_proc = proc do |html_tag, _instance|
+  html_tag.html_safe
+end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -16,10 +16,10 @@ ja:
               confirmation: "が内容とあっていません。"
     attributes:
       user:
-        name: "名前"
-        email: "メールアドレス"
+        name: "ユーザーネーム"
+        email: "Eメール"
         password: "パスワード"
-        password_confirmation: "確認用パスワード"
+        password_confirmation: "パスワード(確認用)"
     models:
       user: "ユーザー"
 

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,4 +1,11 @@
 ja:
+  flash:
+    users:
+      registrations:
+        create:
+          success: "アカウント登録に成功しました"
+          error: "アカウント登録に失敗しました"
+          
   activerecord:
     errors:
       models:


### PR DESCRIPTION
# Pull Request

## Issue
- close: #10 

## 実装内容
新規登録機能を実装しました。
フラッシュメッセージを動的に表示も合わせて実装しています

ページ全体
[![Image from Gyazo](https://i.gyazo.com/02ce8b4d01c8a5500a11b034d3378b34.png)](https://gyazo.com/02ce8b4d01c8a5500a11b034d3378b34)

バリデーションエラー
[![Image from Gyazo](https://i.gyazo.com/e809a5f27406dd94de00698ad9f46639.gif)](https://gyazo.com/e809a5f27406dd94de00698ad9f46639)

成功
[![Image from Gyazo](https://i.gyazo.com/c8cf8f385fa523a341a02a9a866426dc.gif)](https://gyazo.com/c8cf8f385fa523a341a02a9a866426dc)

## issueで書いた実装内容
- 新規登録機能を追加
   - 名前、メールアドレス、パスワード
   - メールアドレスはユニーク属性
   - パスワードはパスワード一致フォームも追加
- 新規登録ページ追加
   - deviceの新規登録ページをカスタマイズ

## issueで書いてやらなかった実装

## issueに書いていないが実装した内容
- ログイン状況に応じたヘッダー表示
   - 理由：ログインできたかどうかわかりやすいため
- バリデーションエラーメッセージ表示
   - 理由：わかりやすくするため

## 動作確認方法
- http://localhost:3000/sign_up で新規登録

## 補足
rubocopの制約が厳しすぎたり今回アプリには不要な成約があったので下記修正しました
- 1メソッドあたりの行数：15行にするかわりにメソッドを増やして回避するのはかえって可読性がわるくなるため、30行に緩めた
- 翻訳表示必須：日本語アプリで海外展開を考えていないため翻訳必須を切る
- 1行あたりの文字数：変なところで改行するとエラーが発生してしまうため

また、保存時のHTML自動フォーマットですが、Ruby記法によるインデント部分が気に食わなかったので一部切っています
```ruby
# 気に食わないの
<%= form_with ... %>
<div>...</div>
<% ebd %>

# 見やすいの
<%= form_with ... %>
   <div>...</div> <!-- Ruby記法の中の要素にインデントを入れられるようにした -->
<% ebd %>
```

## チェックリスト
- [x] 自分でコードレビューを行った
- [x] 動作確認を行った
- [x] lintエラーがないことを確認した