### PR TITLE
feat: マイページと更新実装

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -21,7 +21,16 @@ class Users::RegistrationsController < Devise::RegistrationsController
       clean_up_passwords resource
       set_minimum_password_length
       flash.now[:error] = "アカウント登録に失敗しました"
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
+    end
+  end
+
+  def update
+    if current_user.update(update_params)
+      redirect_to edit_user_registration_path, success: "アカウント情報の更新に成功しました"
+    else
+      flash.now[:error] = "アカウント情報の更新に失敗しました"
+      render :edit, status: :unprocessable_content
     end
   end
 
@@ -29,5 +38,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def sign_up_params
     params.expect(user: %i[name email password password_confirmation])
+  end
+
+  def update_params
+    params.expect(user: %i[name email])
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -11,7 +11,7 @@ class Users::SessionsController < Devise::SessionsController
     else
       flash.now[:error] = "ログインに失敗しました"
       self.resource = resource_class.new
-      render :new, status: :unprocessable_entity
+      render :new, status: :unprocessable_content
     end
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,5 +3,5 @@ class User < ApplicationRecord
 
   validates :name, presence: true
   validates :email, presence: true, uniqueness: true
-  validates :password, presence: true, length: { minimum: 6 }, confirmation: true
+  validates :password, presence: true, length: { minimum: 6 }, confirmation: true, on: :create
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,7 +28,7 @@
       >
         <%= render "shared/flash_message" %>
       </div>
-      <main class="flex w-full grow items-center justify-center px-10 py-2">
+      <main class="flex w-full grow items-start justify-center px-10 py-10">
         <%= yield %>
       </main>
       <footer><%= render "shared/footer" %></footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -8,7 +8,7 @@
         border-theme rounded-full px-5 py-1 text-theme font-semibold", data: { turbo_method: :delete } %>
       </li>
       <li>
-        <%= link_to "マイページ", "#", class: "bg-theme
+        <%= link_to "マイページ", edit_user_registration_path, class: "bg-theme
         rounded-full px-5 py-1 text-primary font-semibold" %>
       </li>
       <% else %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,1 +1,24 @@
-編集ページ
+<div class="flex flex-col justify-center items-center max-w-2xl w-full gap-y-5">
+  <p class="text-start w-full max-w-md "><%= link_to "←戻る", root_path, class: "text-white underline hover:text-gray transition-all w-full" %></p>
+
+  <article class="bg-primary text-white flex flex-col justify-center items-center max-w-md w-full rounded-2xl">
+    <h1 class="text-theme text-2xl text-center border-b border-gray py-3 w-full">マイページ</h1>
+    <%= form_with model: @user, url: user_registration_path, class: "flex flex-col justify-start items-center w-full px-4 py-4 rounded-xl gap-y-4" do |f| %>
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <%= f.label :name %>
+        <%= field_error_message(resource, :name) %>
+        <%= f.text_field :name, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "name name", required: true %>
+      </div>
+
+      <div class="flex flex-col text-start w-full gap-y-2">
+        <%= f.label :email %>
+        <%= field_error_message(resource, :email) %>
+        <%= f.email_field :email, class: "bg-white rounded-lg p-2 text-gray outline-none focus:ring-2 focus:ring-theme", placeholder: "example@example.com", required: true %>
+      </div>
+
+      <div class="flex justify-center items-center">
+        <%= f.submit "更新する", class: "bg-theme text-primary px-4 py-2 rounded-full hover:opacity-50 transition-all cursor-pointer" %>
+      </div>
+    <% end %>
+  </article>
+</div>


### PR DESCRIPTION
# Pull Request

## Issue
- close: #12 

## 実装内容
マイページ及び、名前とメールアドレスの更新を実装しました

マイページ
[![Image from Gyazo](https://i.gyazo.com/23d66e47e4bae561ef8272ea326518e5.png)](https://gyazo.com/23d66e47e4bae561ef8272ea326518e5)

アカウント更新成功
[![Image from Gyazo](https://i.gyazo.com/927da1dd24863e890bc621be82c26376.gif)](https://gyazo.com/927da1dd24863e890bc621be82c26376)

アカウント更新失敗
[![Image from Gyazo](https://i.gyazo.com/b6fad032a68153b198ba5b092872559e.gif)](https://gyazo.com/b6fad032a68153b198ba5b092872559e)

## issueで書いた実装内容
- マイページレイアウト作成
- ユーザーネームを編集・更新できること
- emailを編集・更新できること

## issueで書いてやらなかった実装
なし

## issueに書いていないが実装した内容
ヘッダーからマイページに遷移できるように修正

## 動作確認方法
ログイン後に左上のマイページボタンからマイページへ遷移
ユーザーネームとemailを更新できる

## 補足
figmaでは鉛筆アイコンがあったり更新ボタンがなかったりしますが、この後の挙動についてすり合わせが不足していたので更新ボタンを追加することで更新対応しています。
おそらく
1. 鉛筆アイコンを押す
2. その部分だけフォームになって変更可能
3. 鉛筆アイコンが保存アイコンとかになってそれを押したら更新

だと思うのですが、turboによる更新の場合flashメッセージの更新がちょっとめんどくさかったのでturboなしにしてます
そこまで気になるものでもないので一旦turboじゃなくて良いかなと思ってます

## チェックリスト
- [ ] 自分でコードレビューを行った
- [x] 動作確認を行った
- [x] lintエラーがないことを確認した