### PR TITLE
feat: todo一覧ページ作成

### DIFF
--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -5,6 +5,7 @@
   --color-primary-light: #c2c2c2;
   --color-primary-dark: #111214;
   --color-gray: #4a4c56;
+  --color-gray-light: #aaaaaa;
   --color-cation: #d54a4a;
   --color-theme: #b6ff51;
   --default-font-family: "Noto Sans JP", sans-serif;

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,6 +1,6 @@
 class TodosController < ApplicationController
   def index
-    todos = Todo.includes(:status).all.order(created_at: :asc)
+    todos = Todo.includes(:status).order(created_at: :asc)
     @todos = todos.where(status: { name: "To do" })
     @progress_todos = todos.where(status: { name: "Progress" })
     @done_todos = todos.where(status: { name: "Done" })

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,5 +1,10 @@
 class TodosController < ApplicationController
-  def index; end
+  def index
+    todos = Todo.includes(:status).all.order(created_at: :asc)
+    @todos = todos.where(status: { name: "To do" })
+    @progress_todos = todos.where(status: { name: "Progress" })
+    @done_todos = todos.where(status: { name: "Done" })
+  end
 
   def show; end
 

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,6 +1,6 @@
 <section class="bg-[#2A2F35] p-3">
   <div class="flex flex-col gap-y-1">
-    <h2 class="truncate text-lg font-bold underline"><%= todo.title %></h2>
+    <h2 class="truncate text-lg font-bold underline"><%= link_to todo.title, todo_path(todo) %></h2>
     <p class="text-gray-light truncate"><%= todo.body %></p>
     <p class="text-gray-light mt-1 truncate">
       <%= todo.created_at.in_time_zone('Tokyo').strftime("%Y/%m/%d") %> <%= todo.user.name %>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,0 +1,5 @@
+<section class="bg-[#2A2F35] p-3 flex flex-col gap-y-1">
+  <h2 class="font-bold underline text-lg truncate"><%= todo.title %></h2>
+  <p class="text-gray-light truncate"><%= todo.body %></p>
+  <p class="text-gray-light truncate mt-1"><%= todo.created_at.in_time_zone('Tokyo').strftime("%Y/%m/%d") %> <%= todo.user.name %></p>
+</section>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,5 +1,9 @@
-<section class="bg-[#2A2F35] p-3 flex flex-col gap-y-1">
-  <h2 class="font-bold underline text-lg truncate"><%= todo.title %></h2>
-  <p class="text-gray-light truncate"><%= todo.body %></p>
-  <p class="text-gray-light truncate mt-1"><%= todo.created_at.in_time_zone('Tokyo').strftime("%Y/%m/%d") %> <%= todo.user.name %></p>
+<section class="bg-[#2A2F35] p-3">
+  <div class="flex flex-col gap-y-1">
+    <h2 class="truncate text-lg font-bold underline"><%= todo.title %></h2>
+    <p class="text-gray-light truncate"><%= todo.body %></p>
+    <p class="text-gray-light mt-1 truncate">
+      <%= todo.created_at.in_time_zone('Tokyo').strftime("%Y/%m/%d") %> <%= todo.user.name %>
+    </p>
+  </div>
 </section>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,15 +1,38 @@
-<div class="grid grid-cols-3 w-[1040px] mx-8 gap-x-5 h-[600px]">
-  <article class="p-4 bg-primary rounded-xl flex flex-col gap-y-4 overflow-auto relative">
-    <h1>To do</h1>
-    <div class="grid grid-cols-1 gap-y-4 overflow-y-auto">
-      <%= render @todos %>
+<div class="mx-8 grid w-[1040px] grid-cols-3 gap-x-5">
+  <article class="bg-primary relative rounded-xl">
+    <div class="flex h-[640px] flex-col px-4">
+      <h1 class="py-4">To do</h1>
+      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+        <% @todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
+      </div>
     </div>
-    <%= link_to "+Add item", new_todo_path, class: "sticky bottom-0" %>
+    <div class="bg-primary relative z-10 rounded-b-xl px-6 py-4 text-lg shadow-[0_0_34px_#000000]">
+      <%= link_to "+ Add item", new_todo_path, class: "inline-block w-full hover:opacity-70 transition-all text-theme "
+      %>
+    </div>
   </article>
-  <article class="bg-primary rounded-xl p-4">
-    <h1>Progress</h1>
+  <article class="bg-primary relative rounded-xl">
+    <div class="flex h-[640px] flex-col px-4">
+      <h1 class="py-4">Progress</h1>
+      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+        <% @progress_todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
+      </div>
+    </div>
+    <div class="bg-primary relative z-10 rounded-b-xl px-6 py-4 text-lg shadow-[0_0_34px_#000000]">
+      <%= link_to "+ Add item", new_todo_path, class: "inline-block w-full hover:opacity-70 transition-all text-theme"
+      %>
+    </div>
   </article>
-  <article class="bg-primary rounded-xl p-4">
-    <h1>Done</h1>
+  <article class="bg-primary relative rounded-xl">
+    <div class="flex h-[640px] flex-col px-4">
+      <h1 class="py-4">Done</h1>
+      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+        <% @done_todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
+      </div>
+    </div>
+    <div class="bg-primary relative z-10 rounded-b-xl px-6 py-4 text-lg shadow-[0_0_34px_#000000]">
+      <%= link_to "+ Add item", new_todo_path, class: "inline-block w-full hover:opacity-70 transition-all text-theme"
+      %>
+    </div>
   </article>
 </div>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -1,0 +1,15 @@
+<div class="grid grid-cols-3 w-[1040px] mx-8 gap-x-5 h-[600px]">
+  <article class="p-4 bg-primary rounded-xl flex flex-col gap-y-4 overflow-auto relative">
+    <h1>To do</h1>
+    <div class="grid grid-cols-1 gap-y-4 overflow-y-auto">
+      <%= render @todos %>
+    </div>
+    <%= link_to "+Add item", new_todo_path, class: "sticky bottom-0" %>
+  </article>
+  <article class="bg-primary rounded-xl p-4">
+    <h1>Progress</h1>
+  </article>
+  <article class="bg-primary rounded-xl p-4">
+    <h1>Done</h1>
+  </article>
+</div>


### PR DESCRIPTION
# Pull Request

## Issue
- close: #17 
- 関連issue: 

## 実装内容
todo一覧ページを作成しました

[![Image from Gyazo](https://i.gyazo.com/d8bba78f3b8e3fc6ee9891602e63af62.png)](https://gyazo.com/d8bba78f3b8e3fc6ee9891602e63af62)

## issueで書いた実装内容
- seedデータを使って一覧データ取得
   - status事に分けてtodoをインスタンス
- 一覧全体のレイアウト作成
   - 横スクロールの発生はOK
- 各todoのレイアウト作成
   - _todo.html.erbを使う
   - クリックでtodo詳細ページへ遷移
- Add itemでtodo新規作成ページ遷移

## issueで書いてやらなかった実装
なし

## issueに書いていないが実装した内容
なし

## 動作確認方法
ログイン後にトップページへアクセス

## 補足

## チェックリスト
- [x] 自分でコードレビューを行った
- [x] 動作確認を行った
- [x] lintエラーがないことを確認した