### PR TITLE
feat: todo一覧でtodoの並び替え実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,3 +28,4 @@ end
 
 gem "devise", "~> 4.9"
 gem "devise-i18n"
+gem 'acts_as_list'

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,6 @@ group :development do
   gem "web-console"
 end
 
+gem "acts_as_list"
 gem "devise", "~> 4.9"
 gem "devise-i18n"
-gem 'acts_as_list'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,9 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
+    acts_as_list (1.2.4)
+      activerecord (>= 6.1)
+      activesupport (>= 6.1)
     ast (2.4.3)
     base64 (0.3.0)
     bcrypt (3.1.20)
@@ -321,6 +324,7 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
+  acts_as_list
   bootsnap
   brakeman
   debug

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -29,3 +29,7 @@
     }
   }
 }
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -17,6 +17,12 @@ class TodosController < ApplicationController
 
   def destroy; end
 
+  def increment_position
+    todo = Todo.find(params[:id])
+    todo.move_higher
+    redirect_to root_path
+  end
+
   def decrement_position
     todo = Todo.find(params[:id])
     todo.move_lower

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -1,9 +1,8 @@
 class TodosController < ApplicationController
   def index
-    todos = Todo.includes(:status).order(created_at: :asc)
-    @todos = todos.where(status: { name: "To do" })
-    @progress_todos = todos.where(status: { name: "Progress" })
-    @done_todos = todos.where(status: { name: "Done" })
+    @todos = Status.includes(:todos).find_by(name: "To do").todos
+    @progress_todos = Status.includes(:todos).find_by(name: "Progress").todos
+    @done_todos = Status.includes(:todos).find_by(name: "Done").todos
   end
 
   def show; end
@@ -19,6 +18,8 @@ class TodosController < ApplicationController
   def destroy; end
 
   def decrement_position
+    todo = Todo.find(params[:id])
+    todo.move_lower
     redirect_to root_path
   end
 

--- a/app/controllers/todos_controller.rb
+++ b/app/controllers/todos_controller.rb
@@ -18,6 +18,10 @@ class TodosController < ApplicationController
 
   def destroy; end
 
+  def decrement_position
+    redirect_to root_path
+  end
+
   private
 
   def todo_params

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,5 +1,5 @@
 class Status < ApplicationRecord
-  has_many :todos, dependent: :destroy
+  has_many :todos, -> { order(position: :asc) }
 
   validates :name, presence: true, length: { maximum: 15 }
 end

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,5 +1,5 @@
 class Status < ApplicationRecord
-  has_many :todos, -> { order(position: :asc) }
+  has_many :todos, -> { order(position: :asc) }, dependent: :destroy, inverse_of: :status
 
   validates :name, presence: true, length: { maximum: 15 }
 end

--- a/app/models/todo.rb
+++ b/app/models/todo.rb
@@ -1,6 +1,7 @@
 class Todo < ApplicationRecord
   belongs_to :user
   belongs_to :status
+  acts_as_list scope: %i[status_id]
 
   validates :title, presence: true
   validates :body, presence: true

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -7,7 +7,7 @@
     </p>
   </div>
   <div class="flex w-1/6 flex-col items-center justify-center gap-y-2">
-    <%= link_to "▲", "#", class: "text-theme" %> <%= link_to "▼", decrement_position_todo_path(todo), data: {
-    turbo_method: :patch }, class: "text-theme" %>
+    <%= link_to "▲", increment_position_todo_path(todo), data: { turbo_method: :patch }, class: "text-theme" %> <%=
+    link_to "▼", decrement_position_todo_path(todo), data: { turbo_method: :patch }, class: "text-theme" %>
   </div>
 </section>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -1,9 +1,12 @@
-<section class="bg-[#2A2F35] p-3">
-  <div class="flex flex-col gap-y-1">
+<section class="flex w-[300px] bg-[#2A2F35] p-3">
+  <div class="flex w-5/6 flex-col gap-y-1">
     <h2 class="truncate text-lg font-bold underline"><%= link_to todo.title, todo_path(todo) %></h2>
     <p class="text-gray-light truncate"><%= todo.body %></p>
     <p class="text-gray-light mt-1 truncate">
       <%= todo.created_at.in_time_zone('Tokyo').strftime("%Y/%m/%d") %> <%= todo.user.name %>
     </p>
+  </div>
+  <div class="flex w-1/6 flex-col items-center justify-center gap-y-2">
+    <%= link_to "▲", "#", class: "text-theme" %> <%= link_to "▼", "#", class: "text-theme" %>
   </div>
 </section>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -7,7 +7,7 @@
     </p>
   </div>
   <div class="flex w-1/6 flex-col items-center justify-center gap-y-2">
-    <%= link_to "▲", decrement_position_todo_path(todo), data: { turbo_method: :patch }, class: "text-theme" %> <%=
-    link_to "▼", "#", class: "text-theme" %>
+    <%= link_to "▲", "#", class: "text-theme" %> <%= link_to "▼", decrement_position_todo_path(todo), data: {
+    turbo_method: :patch }, class: "text-theme" %>
   </div>
 </section>

--- a/app/views/todos/_todo.html.erb
+++ b/app/views/todos/_todo.html.erb
@@ -7,6 +7,7 @@
     </p>
   </div>
   <div class="flex w-1/6 flex-col items-center justify-center gap-y-2">
-    <%= link_to "▲", "#", class: "text-theme" %> <%= link_to "▼", "#", class: "text-theme" %>
+    <%= link_to "▲", decrement_position_todo_path(todo), data: { turbo_method: :patch }, class: "text-theme" %> <%=
+    link_to "▼", "#", class: "text-theme" %>
   </div>
 </section>

--- a/app/views/todos/index.html.erb
+++ b/app/views/todos/index.html.erb
@@ -2,7 +2,7 @@
   <article class="bg-primary relative rounded-xl">
     <div class="flex h-[640px] flex-col px-4">
       <h1 class="py-4">To do</h1>
-      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+      <div class="no-scrollbar flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
         <% @todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
       </div>
     </div>
@@ -14,7 +14,7 @@
   <article class="bg-primary relative rounded-xl">
     <div class="flex h-[640px] flex-col px-4">
       <h1 class="py-4">Progress</h1>
-      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+      <div class="no-scrollbar flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
         <% @progress_todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
       </div>
     </div>
@@ -26,7 +26,7 @@
   <article class="bg-primary relative rounded-xl">
     <div class="flex h-[640px] flex-col px-4">
       <h1 class="py-4">Done</h1>
-      <div class="flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
+      <div class="no-scrollbar flex h-full flex-col gap-y-4 overflow-y-auto pb-4">
         <% @done_todos.each do |todo| %> <%= render "todos/todo", todo: todo %> <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,5 +7,9 @@ Rails.application.routes.draw do
                        sessions: "users/sessions",
                        registrations: "users/registrations"
                      }
-  resources :todos, except: %i[index]
+  resources :todos, except: %i[index] do
+    member do
+      patch :decrement_position
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :todos, except: %i[index] do
     member do
       patch :decrement_position
+      patch :increment_position
     end
   end
 end

--- a/db/migrate/20250923053131_add_position_to_todo.rb
+++ b/db/migrate/20250923053131_add_position_to_todo.rb
@@ -1,0 +1,5 @@
+class AddPositionToTodo < ActiveRecord::Migration[8.0]
+  def change
+    add_column :todos, :position, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_20_123624) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_23_053131) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -27,6 +27,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_20_123624) do
     t.bigint "status_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "position"
     t.index ["status_id"], name: "index_todos_on_status_id"
     t.index ["user_id"], name: "index_todos_on_user_id"
   end


### PR DESCRIPTION
# Issue
- close: #25 
- 関連issue: 
   - #16 

# 実装内容
todo一覧ページにおいて、todoの▲▼ボタンを押すことでtodoの順番をstatus内で移動できるように実装しました。

[![Image from Gyazo](https://i.gyazo.com/82aea22a54db8047557b8e7b6c8516d3.gif)](https://gyazo.com/82aea22a54db8047557b8e7b6c8516d3)

# issueで書いた実装内容
- #16 で調査しているので、その実装を行う
- 機能を実装する
- todo詳細（1todo）に上下にできるボタンを表示する

# issueで書いてやらなかった実装
なし

# issueに書いていないが実装した内容
なし

# 動作確認方法
http://localhost:3000/ にアクセス
１todoあたりの▲▼ボタンを押すと、status内で上や下にtodoが移動する

# 補足

## チェックリスト
- [x] 自分でコードレビューを行った
- [x] 動作確認を行った
- [x] lintエラーがないことを確認した